### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,18 +21,18 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "JSONStream": "^0.8.4",
-    "cookie-cutter": "^0.1.1",
+    "JSONStream": "0.8.4",
+    "cookie-cutter": "0.1.1",
     "hyperdirect": "0.0.0",
-    "hyperglue": "^1.3.0",
-    "hyperquest": "^0.3.0",
-    "lame": "^1.2.2",
-    "speaker": "^0.2.1",
+    "hyperglue": "1.3.3",
+    "hyperquest": "0.3.0",
+    "lame": "1.2.3",
+    "speaker": "0.2.6",
     "spotify-web": "git+ssh://git@github.com/fuzeman/node-spotify-web.git#feature/ping-pong-fix",
-    "stack": "^0.1.0",
-    "supervisor": "^0.6.0",
-    "through": "^2.3.4",
-    "tiny-route": "^2.1.1",
+    "stack": "0.1.0",
+    "supervisor": "0.6.0",
+    "through": "2.3.8",
+    "tiny-route": "2.1.1",
     "youtube-audio-stream": "0.0.5"
   }
 }


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:
- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
