### PR TITLE
Updated youtube-audio-stream to version 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "supervisor": "0.9.1",
     "through": "2.3.8",
     "tiny-route": "2.1.1",
-    "youtube-audio-stream": "0.0.5"
+    "youtube-audio-stream": "0.0.6"
   }
 }


### PR DESCRIPTION
:rocket:

youtube-audio-stream just published version 0.0.6, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 5 commits (ahead by 5, behind by 0).
- [7eb2a2c](https://github.com/JamesKyburz/youtube-audio-stream/commit/7eb2a2c82c5bcaacff1a22db5c02cceaab67a742): 0.0.6
- [4433b24](https://github.com/JamesKyburz/youtube-audio-stream/commit/4433b24d5c27b7e5d29390c280638731e061ec13): Merge pull request #12 from JamesKyburz/greenkeeper-through2-2.0.0
- [01b187b](https://github.com/JamesKyburz/youtube-audio-stream/commit/01b187b8a2fe642269e478b7a0fa5ab3a20cda2f): chore(package): update through2 to version 2.0.0
- [36eb307](https://github.com/JamesKyburz/youtube-audio-stream/commit/36eb3072183e99a8af6a4b3dd215377859f2feca): Merge pull request #11 from JamesKyburz/greenkeeper-pin
- [9ae8910](https://github.com/JamesKyburz/youtube-audio-stream/commit/9ae8910c7b0d5245dadd5540bf17841c9aa460f2): chore(package): pin dependencies

See the [full diff](https://github.com/JamesKyburz/youtube-audio-stream/compare/89b8c5d6b1b3f6bb6e30168241c6af95ea1b0025...7eb2a2c82c5bcaacff1a22db5c02cceaab67a742).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
